### PR TITLE
Remove Swagger and set login page as default

### DIFF
--- a/GPTCodexApi.csproj
+++ b/GPTCodexApi.csproj
@@ -7,8 +7,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.16" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.6.2" />
     <PackageReference Include="BCrypt.Net-Next" Version="4.0.2" />
   </ItemGroup>
 

--- a/Program.cs
+++ b/Program.cs
@@ -1,24 +1,16 @@
 var builder = WebApplication.CreateBuilder(args);
 
 // Add services to the container.
-// Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
-builder.Services.AddEndpointsApiExplorer();
-builder.Services.AddSwaggerGen();
 builder.Services.AddSingleton<UserService>();
 
 var app = builder.Build();
 app.UseStaticFiles();
 
 // Configure the HTTP request pipeline.
-if (app.Environment.IsDevelopment())
-{
-    app.UseSwagger();
-    app.UseSwaggerUI();
-}
-
-app.MapGet("/login", () => Results.File("wwwroot/login.html", "text/html"));
-app.MapGet("/signup", () => Results.File("wwwroot/signup.html", "text/html"));
-app.MapGet("/verify", () => Results.File("wwwroot/verify.html", "text/html"));
+app.MapGet("/", () => Results.File(Path.Combine(app.Environment.ContentRootPath, "wwwroot", "login.html"), "text/html"));
+app.MapGet("/login", () => Results.File(Path.Combine(app.Environment.ContentRootPath, "wwwroot", "login.html"), "text/html"));
+app.MapGet("/signup", () => Results.File(Path.Combine(app.Environment.ContentRootPath, "wwwroot", "signup.html"), "text/html"));
+app.MapGet("/verify", () => Results.File(Path.Combine(app.Environment.ContentRootPath, "wwwroot", "verify.html"), "text/html"));
 
 var codes = new Dictionary<string, string>();
 
@@ -80,8 +72,7 @@ app.MapGet("/weatherforecast", () =>
         .ToArray();
     return forecast;
 })
-.WithName("GetWeatherForecast")
-.WithOpenApi();
+.WithName("GetWeatherForecast");
 
 app.Run();
 


### PR DESCRIPTION
## Summary
- remove Swagger references
- serve `login.html` by default
- use project root for static page locations

## Testing
- `dotnet build`
- `dotnet run --no-build` and `curl http://localhost:5259/ -s | head -n 5`

------
https://chatgpt.com/codex/tasks/task_e_6846faa086448323b847569f75237962