### PR TITLE
Implement verification redirect and dashboard

### DIFF
--- a/UserService.cs
+++ b/UserService.cs
@@ -5,6 +5,7 @@ public class User
 {
     public string Email { get; set; } = string.Empty;
     public string PasswordHash { get; set; } = string.Empty;
+    public bool Verified { get; set; }
 }
 
 public class UserService
@@ -29,7 +30,12 @@ public class UserService
     public bool AddUser(string email, string password)
     {
         if (_users.ContainsKey(email)) return false;
-        var user = new User { Email = email, PasswordHash = BCrypt.Net.BCrypt.HashPassword(password) };
+        var user = new User
+        {
+            Email = email,
+            PasswordHash = BCrypt.Net.BCrypt.HashPassword(password),
+            Verified = false
+        };
         _users[email] = user;
         Save();
         return true;
@@ -42,6 +48,18 @@ public class UserService
             return BCrypt.Net.BCrypt.Verify(password, user.PasswordHash);
         }
         return false;
+    }
+
+    public bool IsVerified(string email) =>
+        _users.TryGetValue(email, out var user) && user.Verified;
+
+    public void MarkVerified(string email)
+    {
+        if (_users.TryGetValue(email, out var user))
+        {
+            user.Verified = true;
+            Save();
+        }
     }
 
     private void Save()

--- a/wwwroot/dashboard.html
+++ b/wwwroot/dashboard.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <link rel="stylesheet" href="/style.css" />
+    <title>Dashboard</title>
+</head>
+<body>
+<nav class="navbar">
+    <div class="logo">Codex</div>
+</nav>
+<div class="container">
+    <h1>Mock Dashboard</h1>
+    <p>Welcome! You have successfully logged in.</p>
+</div>
+</body>
+</html>

--- a/wwwroot/verify.html
+++ b/wwwroot/verify.html
@@ -11,10 +11,17 @@
 <div class="container">
     <h1>Enter code</h1>
     <form method="post" action="/verify">
+        <input type="hidden" name="email" id="email" />
         <input type="text" name="code" placeholder="Code" required />
         <button type="submit">Verify</button>
     </form>
     <p class="small">We've sent a code to your email. (Simulated)</p>
+    <p class="small">Your code is: <span id="display-code"></span></p>
 </div>
+<script>
+    const params = new URLSearchParams(window.location.search);
+    document.getElementById('display-code').textContent = params.get('code') || '';
+    document.getElementById('email').value = params.get('email') || '';
+</script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add verification status to users
- redirect unverified users from login to verification page
- show verification code on verification page
- mark users verified and go to dashboard after code entry
- add simple dashboard page

## Testing
- `dotnet build --no-restore` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846fd98e28883238f6e9325f542cd1d